### PR TITLE
Fix Tailwind config import

### DIFF
--- a/korikosmos-dev/tailwind.config.mjs
+++ b/korikosmos-dev/tailwind.config.mjs
@@ -1,6 +1,5 @@
-import { defineConfig } from 'tailwindcss';
-
-export default defineConfig({
+/** @type {import('tailwindcss').Config} */
+export default {
   content: [
     "./src/**/*.{astro,html,js,jsx,ts,tsx,md,mdx}",
   ],
@@ -8,4 +7,4 @@ export default defineConfig({
     extend: {},
   },
   plugins: [],
-});
+};


### PR DESCRIPTION
## Summary
- fix `tailwind.config.mjs` to export config object without importing `defineConfig`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868b301d530832b90ddf446f62c24cb