### PR TITLE
Add Last.fm tunes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # korikosmos.dev
 Personal Website
+
+## Setup
+
+Copy `.env.example` to `.env` inside `korikosmos-dev` and fill in your Last.fm credentials:
+
+```
+cp korikosmos-dev/.env.example korikosmos-dev/.env
+```
+
+Edit the new `.env` file and set `LASTFM_USER` and `LASTFM_API_KEY`.

--- a/korikosmos-dev/.env.example
+++ b/korikosmos-dev/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for Last.fm integration
+LASTFM_USER=
+LASTFM_API_KEY=

--- a/korikosmos-dev/README.md
+++ b/korikosmos-dev/README.md
@@ -1,5 +1,6 @@
 # Astro Starter Kit: Basics
 
+Before running the project, copy `.env.example` to `.env` and provide your Last.fm credentials.
 ```sh
 npm create astro@latest -- --template basics
 ```

--- a/korikosmos-dev/src/pages/tunes.astro
+++ b/korikosmos-dev/src/pages/tunes.astro
@@ -1,3 +1,66 @@
 ---
+import Layout from '../layouts/Layout.astro';
 
+const { LASTFM_USER, LASTFM_API_KEY } = Astro.env;
+const user = LASTFM_USER;
+const apiKey = LASTFM_API_KEY;
+
+async function fetchLastFm(method) {
+  const url = `https://ws.audioscrobbler.com/2.0/?method=${method}&user=${user}&api_key=${apiKey}&format=json`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    return null;
+  }
+  return await res.json();
+}
+
+const recentData = await fetchLastFm('user.getrecenttracks');
+const topTracksData = await fetchLastFm('user.gettoptracks');
+const topArtistsData = await fetchLastFm('user.gettopartists');
+
+const recentTracks = recentData?.recenttracks?.track?.slice(0,5) ?? [];
+const topTracks = topTracksData?.toptracks?.track?.slice(0,5) ?? [];
+const topArtists = topArtistsData?.topartists?.artist?.slice(0,5) ?? [];
 ---
+
+<Layout title="Tunes">
+  <h1 class="text-3xl font-bold my-6">Tunes</h1>
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold mb-4">Recent Tracks</h2>
+    <ul class="space-y-2">
+      {recentTracks.map(track => (
+        <li class="border-b pb-2" key={track.mbid || track.url}>
+          <a href={track.url} class="hover:underline" target="_blank">
+            {track.artist['#text']} – {track.name}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
+
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold mb-4">Top Tracks</h2>
+    <ol class="list-decimal pl-5 space-y-2">
+      {topTracks.map((track, i) => (
+        <li key={track.mbid || track.url}>
+          <a href={track.url} class="hover:underline" target="_blank">
+            {track.artist.name} – {track.name}
+          </a>
+        </li>
+      ))}
+    </ol>
+  </section>
+
+  <section class="mb-8">
+    <h2 class="text-2xl font-semibold mb-4">Top Artists</h2>
+    <ol class="list-decimal pl-5 space-y-2">
+      {topArtists.map((artist, i) => (
+        <li key={artist.mbid || artist.url}>
+          <a href={artist.url} class="hover:underline" target="_blank">
+            {artist.name}
+          </a>
+        </li>
+      ))}
+    </ol>
+  </section>
+</Layout>


### PR DESCRIPTION
## Summary
- add environment variable example file for Last.fm
- fetch recent tracks, top tracks and top artists on `/tunes`
- document setup for Last.fm in READMEs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868b611f788832b95c3c69295eb6c93