### PR TITLE
Clarify env instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ cp korikosmos-dev/.env.example korikosmos-dev/.env
 ```
 
 Edit the new `.env` file and set `LASTFM_USER` and `LASTFM_API_KEY`.
+
+Astro will read variables from this `.env` file automatically. These values can
+be accessed in server-side code through `Astro.env`. Note that `Astro.env` is
+not a file; it is the object representing your environment variables at runtime.

--- a/korikosmos-dev/README.md
+++ b/korikosmos-dev/README.md
@@ -1,6 +1,7 @@
 # Astro Starter Kit: Basics
 
 Before running the project, copy `.env.example` to `.env` and provide your Last.fm credentials.
+Astro automatically loads variables from this `.env` file and exposes them to server-side code through `Astro.env`.
 ```sh
 npm create astro@latest -- --template basics
 ```


### PR DESCRIPTION
## Summary
- clarify that `.env` values load into `Astro.env` in root README
- add the same note to the example project README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6868b8141294832ba613e50a33f3f7b4