### PR TITLE
Fix env handling for static build

### DIFF
--- a/Astro-README.md
+++ b/Astro-README.md
@@ -1,7 +1,7 @@
 # Astro Starter Kit: Basics
 
 Before running the project, copy `.env.example` to `.env` and provide your Last.fm credentials.
-Astro automatically loads variables from this `.env` file and exposes them to server-side code through `Astro.env`.
+Astro automatically loads variables from this `.env` file. Access them with `import.meta.env` when building a static site. `Astro.env` is only available when running with a server output.
 ```sh
 npm create astro@latest -- --template basics
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ cp korikosmos-dev/.env.example korikosmos-dev/.env
 
 Edit the new `.env` file and set `LASTFM_USER` and `LASTFM_API_KEY`.
 
-Astro will read variables from this `.env` file automatically. These values can
-be accessed in server-side code through `Astro.env`. Note that `Astro.env` is
-not a file; it is the object representing your environment variables at runtime.
+Astro will read variables from this `.env` file automatically. For static
+builds, use `import.meta.env` to access these values in your server-side code.
+`Astro.env` is only available when running with a server output.

--- a/src/pages/tunes.astro
+++ b/src/pages/tunes.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 
-const { LASTFM_USER, LASTFM_API_KEY } = Astro.env;
+const { LASTFM_USER, LASTFM_API_KEY } = import.meta.env;
 const user = LASTFM_USER;
 const apiKey = LASTFM_API_KEY;
 


### PR DESCRIPTION
## Summary
- explain env access in README and Astro-README
- use `import.meta.env` instead of `Astro.env` in `tunes.astro`

## Testing
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6868bad1edf4832bbc1d66ae159b82ef