### PR TITLE
Add under construction component and update pages

### DIFF
--- a/src/components/UnderConstruction.astro
+++ b/src/components/UnderConstruction.astro
@@ -1,0 +1,6 @@
+---
+---
+<div class="text-center py-20">
+  <h1 class="text-4xl font-bold mb-4">Under Construction</h1>
+  <p class="text-lg">This page is still a work in progress.</p>
+</div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,3 +1,8 @@
 ---
-
+import Layout from '../layouts/Layout.astro';
+import UnderConstruction from '../components/UnderConstruction.astro';
 ---
+
+<Layout title="About">
+  <UnderConstruction />
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,3 +1,8 @@
 ---
-
+import Layout from '../../layouts/Layout.astro';
+import UnderConstruction from '../../components/UnderConstruction.astro';
 ---
+
+<Layout title="Blog">
+  <UnderConstruction />
+</Layout>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,3 +1,8 @@
 ---
-
+import Layout from '../layouts/Layout.astro';
+import UnderConstruction from '../components/UnderConstruction.astro';
 ---
+
+<Layout title="CV">
+  <UnderConstruction />
+</Layout>

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -1,3 +1,8 @@
 ---
-
+import Layout from '../layouts/Layout.astro';
+import UnderConstruction from '../components/UnderConstruction.astro';
 ---
+
+<Layout title="Portfolio">
+  <UnderConstruction />
+</Layout>


### PR DESCRIPTION
## Summary
- add a reusable **Under Construction** component
- show that component on the About, CV, Blog and Portfolio pages

## Testing
- `npm run build` *(fails: fetch failed during tunes page build)*

------
https://chatgpt.com/codex/tasks/task_e_6868c2bef0d8832ba2d47281014a607c