### PR TITLE
Add portfolio project pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ Your Last.fm API key is only used on the server and never sent to the browser.
 - Displays your most recently played tracks with accompanying album artwork.
 
 - Toggle a cute cursor-following cat using the corner button.
+
+- Showcase personal projects on the Portfolio page. Add new entries in
+  `src/data/projects.js` to link GitHub repos or describe non-git work.

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,0 +1,7 @@
+---
+const { project } = Astro.props;
+---
+<a href={`/portfolio/${project.slug}`} class="block bg-gray-800/60 rounded-lg p-4 hover:bg-gray-700 transition">
+  <h2 class="text-xl font-semibold mb-2">{project.title}</h2>
+  <p class="text-gray-400">{project.summary}</p>
+</a>

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1,0 +1,20 @@
+export const projects = [
+  {
+    slug: 'random-project',
+    title: 'Random Project',
+    summary: 'A small standalone experiment.',
+    description: 'This project demonstrates work that isn\'t hosted on GitHub but still deserves a spotlight.',
+    github: null
+  },
+  {
+    slug: 'korikosmos-dev',
+    title: 'korikosmos.dev',
+    summary: 'My personal website built with Astro.',
+    description: 'The source code for this site is open and available to explore.',
+    github: 'https://github.com/KoriKosmos/korikosmos.dev'
+  }
+];
+
+export function getProject(slug) {
+  return projects.find(p => p.slug === slug);
+}

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -1,8 +1,12 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import UnderConstruction from '../components/UnderConstruction.astro';
+import ProjectCard from '../components/ProjectCard.astro';
+import { projects } from '../data/projects.js';
 ---
 
 <Layout title="Portfolio">
-  <UnderConstruction />
+  <h1 class="text-3xl font-bold my-6">Portfolio</h1>
+  <div class="grid gap-6 sm:grid-cols-2">
+    {projects.map(p => <ProjectCard project={p} />)}
+  </div>
 </Layout>

--- a/src/pages/portfolio/[slug].astro
+++ b/src/pages/portfolio/[slug].astro
@@ -1,0 +1,30 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getProject, projects } from '../../data/projects.js';
+
+export function getStaticPaths() {
+  return projects.map(p => ({ params: { slug: p.slug } }));
+}
+
+const { slug } = Astro.params;
+const project = getProject(slug);
+---
+
+<Layout title={project ? project.title : 'Project'}>
+  {project ? (
+    <article class="my-8 space-y-4">
+      <h1 class="text-3xl font-bold">{project.title}</h1>
+      <p>{project.description}</p>
+      {project.github && (
+        <a href={project.github} class="inline-flex items-center mt-4 px-4 py-2 bg-gray-800 rounded hover:bg-gray-700">
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path fill-rule="evenodd" d="M12 0C5.37 0 0 5.37 0 12c0 5.303 3.438 9.8 8.205 11.387.6.113.82-.26.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.089-.745.083-.73.083-.73 1.205.085 1.84 1.236 1.84 1.236 1.07 1.835 2.807 1.305 3.492.998.108-.775.418-1.305.76-1.605-2.665-.305-5.466-1.334-5.466-5.93 0-1.31.467-2.38 1.235-3.22-.123-.303-.535-1.523.117-3.176 0 0 1.008-.322 3.3 1.23a11.5 11.5 0 013.003-.404c1.02.005 2.047.138 3.003.404 2.29-1.552 3.296-1.23 3.296-1.23.653 1.653.241 2.873.118 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.804 5.624-5.475 5.921.43.372.813 1.102.813 2.222 0 1.606-.014 2.898-.014 3.293 0 .32.216.694.825.576C20.565 21.796 24 17.3 24 12c0-6.63-5.37-12-12-12z" clip-rule="evenodd"/>
+          </svg>
+          <span class="ml-2">View on Github</span>
+        </a>
+      )}
+    </article>
+  ) : (
+    <p class="my-8">Project not found.</p>
+  )}
+</Layout>


### PR DESCRIPTION
## Summary
- list projects on portfolio page
- add reusable card component
- dynamic project pages with optional GitHub link
- document portfolio data file

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bdde77154832ba95aba18d6e2a85b