### PR TITLE
Add Dockerfile and compose setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,4 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Keep the main `README.md` up to date. Avoid writing documentation changes only in `Astro-README.md`.
 - Use a first-person voice in docs. Write from my perspective.
 - Sync useful content from Astro-README.md back to README.md when needed.
+- Dockerfile and docker-compose.yml allow containerized builds with `docker compose up --build`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18 AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -60,3 +60,13 @@ Run these from the project root:
 | `npm run build`     | Build the production site to `./dist/`         |
 | `npm run preview`   | Preview the built site locally                 |
 | `npm run astro ...` | Run additional Astro CLI commands              |
+
+## Docker
+
+Use Docker to build and preview the site without installing Node locally:
+
+```sh
+docker compose up --build
+```
+
+The site will be available at http://localhost:8080. Remember to provide `LASTFM_USER` and `LASTFM_API_KEY` in your environment when building.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    environment:
+      - LASTFM_USER=${LASTFM_USER}
+      - LASTFM_API_KEY=${LASTFM_API_KEY}


### PR DESCRIPTION
## Summary
- add Dockerfile with multi-stage build using Nginx
- add docker-compose.yml for easy local deployment
- document Docker usage in README
- update AGENTS notes about Docker support

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cfc500d68832b8818bf09246da07c