### PR TITLE
Add Git update on container startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,5 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Keep the main `README.md` up to date. Avoid writing documentation changes only in `Astro-README.md`.
 - Use a first-person voice in docs. Write from my perspective.
 - Sync useful content from Astro-README.md back to README.md when needed.
+- Dockerfile and docker-compose.yml allow containerized builds with `docker compose up --build`.
+- The container will run `git pull` on startup using `GIT_REPO` and rebuild the site automatically.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:18
+
+# Install git and nginx
+RUN apt-get update \
+ && apt-get install -y git nginx \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies separately so they can be cached
+COPY package*.json ./
+RUN npm install
+
+# Copy the rest of the repo
+COPY . .
+
+# Include entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 80
+CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -60,3 +60,13 @@ Run these from the project root:
 | `npm run build`     | Build the production site to `./dist/`         |
 | `npm run preview`   | Preview the built site locally                 |
 | `npm run astro ...` | Run additional Astro CLI commands              |
+
+## Docker
+
+Use Docker to build and preview the site without installing Node locally:
+
+```sh
+docker compose up --build
+```
+
+The site will be available at http://localhost:8080. I can also set `GIT_REPO` to a GitHub URL so the container pulls the latest changes each time it starts. Optionally set `GIT_BRANCH` if I need a branch other than `main`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    environment:
+      - LASTFM_USER=${LASTFM_USER}
+      - LASTFM_API_KEY=${LASTFM_API_KEY}
+      - GIT_REPO=${GIT_REPO}
+      - GIT_BRANCH=${GIT_BRANCH:-main}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+# Pull latest changes if a repo is provided
+if [ -n "$GIT_REPO" ]; then
+  if [ ! -d /app/.git ]; then
+    echo "Cloning $GIT_REPO"
+    rm -rf /app/*
+    git clone --depth 1 --branch ${GIT_BRANCH:-main} "$GIT_REPO" /app
+  else
+    echo "Updating existing repo"
+    git -C /app pull "$GIT_REPO" ${GIT_BRANCH:-main}
+  fi
+fi
+
+cd /app
+npm install
+npm run build
+rm -rf /usr/share/nginx/html/*
+cp -r dist/* /usr/share/nginx/html/
+
+nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- add docker-entrypoint.sh that pulls from GIT_REPO and rebuilds
- modify Dockerfile to use the entrypoint and include git and nginx
- update docker-compose with GIT_REPO and optional GIT_BRANCH vars
- document auto-update behavior in README
- note git pull step in AGENTS guidelines

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cfc500d68832b8818bf09246da07c