### PR TITLE
Add About page content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,4 +49,5 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Docker entrypoint should copy the build output to `/var/www/html` since that's
   the default Nginx root.
 - Docker listens on port `8484` by default via `docker-compose.yml`.
+- About page now includes a short biography using the same card styling as other pages.
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,8 +1,14 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import UnderConstruction from '../components/UnderConstruction.astro';
 ---
 
 <Layout title="About">
-  <UnderConstruction />
+  <section class="bg-gray-800/60 rounded-lg p-6 shadow space-y-4 mt-8">
+    <h1 class="text-3xl font-bold mb-4 text-center">About Me</h1>
+    <p>Hi, I’m Maan. I’m someone who enjoys thoughtful storytelling, whether it comes from comics, manga, films, or games. I’ve always been drawn to creative worlds and the ideas behind them — not just how they're made, but why they resonate with people.</p>
+
+    <p>I’ve lived in several countries, and that experience has shaped my perspective — I adapt quickly, stay curious, and value open-minded conversations. In my free time, I enjoy reading, watching character-driven dramas or animation, and diving into games that offer more than just action — ones that tell a story or challenge the way you think.</p>
+
+    <p>Outside of entertainment, I like to organise and improve things. Whether that’s setting up my home server, building tools, or just refining a small personal project, I find satisfaction in making systems work better. I enjoy learning new skills, but I also value quiet time to reflect or explore new ideas at my own pace.</p>
+  </section>
 </Layout>


### PR DESCRIPTION
## Summary
- flesh out About page with biography and consistent styling
- note About page update in AGENTS guide

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d2a1ee9a8832b94511d46e6991651