### PR TITLE
Fix Oneko toggle persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,4 +50,5 @@ This project contains the source for **korikosmos.dev**, a personal site built w
   the default Nginx root.
 - Docker listens on port `8484` by default via `docker-compose.yml`.
 - About page now includes a short biography using the same card styling as other pages.
+- Cat toggle now persists across pages so Oneko can follow you site-wide.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm run dev
 ## Features
 
 - Displays my most recently played tracks with album artwork
-- Toggle a little cursor-following cat from the corner button
+ - Toggle a little cursor-following cat from the corner button. Once enabled, it follows me across every page
 - Showcases my projects from `src/content/projects`
 - Manage posts and projects from Netlify CMS at `/admin`
 - Responsive Tailwind styling

--- a/src/components/OnekoToggle.astro
+++ b/src/components/OnekoToggle.astro
@@ -35,5 +35,6 @@ toggleBtn.addEventListener('click', () => {
     enable();
   }
 });
+updateFromStorage();
 window.addEventListener('load', updateFromStorage);
 </script>


### PR DESCRIPTION
## Summary
- ensure the Oneko toggle runs immediately on page load
- mention the site-wide cat toggle in the README
- note the new behaviour in AGENTS.md

## Testing
- `npm run build`

