### PR TITLE
Add Games page and navigation link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,16 @@
 # Development Guidelines
 
-This project contains the source for **korikosmos.dev**, a personal site built with [Astro](https://astro.build/). It serves as a portfolio hub, CV, blog and music showcase.
+This project contains the source for **korikosmos.dev**, a personal site built with [Astro](https://astro.build/). It serves as a portfolio hub, CV, blog, games page and music showcase.
 
 ## Site Structure & Objectives
 
 - `src/pages/index.astro` – Landing page with a short greeting and link to the portfolio.
-- `src/pages/about.astro` – Will provide a biography; currently uses the `UnderConstruction` component.
+- `src/pages/about.astro` – Short biography using card styling.
 - `src/pages/cv.astro` – Full curriculum vitae including education, skills and work history.
 - `src/pages/portfolio.astro` – Lists projects from `src/content/projects`.
 - `src/pages/blog/` – Blog posts generated from Markdown content.
 - `src/pages/tunes.astro` – Displays recent Last.fm tracks and requires `LASTFM_USER` and `LASTFM_API_KEY` in `.env`.
+- `src/pages/games.astro` – Placeholder for games page using `UnderConstruction`.
 - `src/layouts/Layout.astro` – Base layout used by pages; includes navigation links and the oneko cat toggle.
 - `src/components/UnderConstruction.astro` – Simple component indicating a page is unfinished.
 - `src/content/` – Markdown files managed by Netlify CMS at `/admin`.
@@ -55,3 +56,4 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Cat toggle now persists across pages so Oneko can follow you site-wide.
 - Theme bar allows switching between "dark", "light", and "forest" themes using a fixed selector on every page.
 - Portfolio now includes pages for my Final Year Project and Year 2 Java calculator.
+- Navigation now links to a placeholder Games page.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # korikosmos.dev
 
-This repo contains the source for **korikosmos.dev**, my personal website built with [Astro](https://astro.build) and Tailwind CSS. Here I share my projects, CV, blog posts and the music I'm currently listening to.
+This repo contains the source for **korikosmos.dev**, my personal website built with [Astro](https://astro.build) and Tailwind CSS. Here I share my projects, CV, blog posts, games and the music I'm currently listening to.
 
 ## Setup
 
@@ -34,6 +34,7 @@ npm run dev
 - Manage posts and projects from Netlify CMS at `/admin`
 - Responsive Tailwind styling
 - Includes dedicated pages for my Final Year Project and Year 2 Java calculator
+- Placeholder games page linked from the navigation
 
 ## Project Structure
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,11 +16,12 @@ const { title = 'KoriKosmos' } = Astro.props
 	<nav class="flex gap-4">
 		<a href="/" class="hover:underline">Home</a>
 		<a href="/about" class="hover:underline">About</a>
-		<a href="/portfolio" class="hover:underline">Portfolio</a>
-		<a href="/cv" class="hover:underline">CV</a>
-		<a href="/tunes" class="hover:underline">Tunes</a>
-		<a href="/blog" class="hover:underline">Blog</a>
-	</nav>
+                <a href="/portfolio" class="hover:underline">Portfolio</a>
+                <a href="/cv" class="hover:underline">CV</a>
+                <a href="/tunes" class="hover:underline">Tunes</a>
+                <a href="/games" class="hover:underline">Games</a>
+                <a href="/blog" class="hover:underline">Blog</a>
+        </nav>
 </header>
 
 <main class="max-w-3xl mx-auto px-4">

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import UnderConstruction from '../components/UnderConstruction.astro';
+---
+
+<Layout title="Games">
+  <UnderConstruction />
+</Layout>


### PR DESCRIPTION
## Summary
- Add Games tab to site navigation
- Create placeholder Games page
- Document Games page in README and AGENTS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68990176b940832bba5cc7e1bbb9a875