### PR TITLE
Add next and hold previews to Tetris game

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,4 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Theme bar allows switching between "dark", "light", and "forest" themes using a fixed selector on every page.
 - Portfolio now includes pages for my Final Year Project and Year 2 Java calculator.
 - Games page now lists a playable Tetris subpage.
+- Tetris now shows the next piece and lets me hold one with C or Shift.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm run dev
 - Manage posts and projects from Netlify CMS at `/admin`
 - Responsive Tailwind styling
 - Includes dedicated pages for my Final Year Project and Year 2 Java calculator
-- Playable Tetris clone on the Games page
+- Playable Tetris clone on the Games page with next-piece preview and a hold function (press C or Shift to hold)
 
 ## Project Structure
 

--- a/src/pages/games/tetris.astro
+++ b/src/pages/games/tetris.astro
@@ -6,10 +6,20 @@ import Layout from '../../layouts/Layout.astro';
   <h1 class="text-3xl font-bold my-6">Tetris</h1>
   <div class="flex gap-4">
     <canvas id="board" width="300" height="600"></canvas>
-    <div class="space-y-2">
-      <p>Score: <span id="score">0</span></p>
-      <p>Lines: <span id="lines">0</span></p>
-      <p>Level: <span id="level">0</span></p>
+    <div class="space-y-4">
+      <div>
+        <p class="font-bold">Next</p>
+        <canvas id="next" width="120" height="120"></canvas>
+      </div>
+      <div>
+        <p class="font-bold">Hold</p>
+        <canvas id="hold" width="120" height="120"></canvas>
+      </div>
+      <div class="space-y-2">
+        <p>Score: <span id="score">0</span></p>
+        <p>Lines: <span id="lines">0</span></p>
+        <p>Level: <span id="level">0</span></p>
+      </div>
     </div>
   </div>
   <script>
@@ -20,17 +30,25 @@ const SIZE = 30;
 const canvas = document.getElementById('board');
 const ctx = canvas.getContext('2d');
 
-// Optional: improve crispness on HiDPI screens
-(function scaleForHiDPI() {
+const nextCanvas = document.getElementById('next');
+const nextCtx = nextCanvas.getContext('2d');
+
+const holdCanvas = document.getElementById('hold');
+const holdCtx = holdCanvas.getContext('2d');
+function scaleForHiDPI(c, context) {
   const dpr = window.devicePixelRatio || 1;
   if (dpr !== 1) {
-    canvas.style.width = canvas.width + 'px';
-    canvas.style.height = canvas.height + 'px';
-    canvas.width = Math.floor(canvas.width * dpr);
-    canvas.height = Math.floor(canvas.height * dpr);
-    ctx.scale(dpr, dpr);
+    c.style.width = c.width + 'px';
+    c.style.height = c.height + 'px';
+    c.width = Math.floor(c.width * dpr);
+    c.height = Math.floor(c.height * dpr);
+    context.scale(dpr, dpr);
   }
-})();
+}
+
+scaleForHiDPI(canvas, ctx);
+scaleForHiDPI(nextCanvas, nextCtx);
+scaleForHiDPI(holdCanvas, holdCtx);
 
 // --- Scoring ---
 let score = 0;
@@ -86,17 +104,17 @@ let dropInterval = 800; // ms per row at start (we can speed up later)
 
 
 // Draw one cell
-function drawCell(x, y, color) {
-  const px = x * SIZE;
-  const py = y * SIZE;
+function drawCell(x, y, color, context = ctx, size = SIZE) {
+  const px = x * size;
+  const py = y * size;
 
   // base
-  ctx.fillStyle = color;
-  ctx.fillRect(px, py, SIZE, SIZE);
+  context.fillStyle = color;
+  context.fillRect(px, py, size, size);
 
   // tiny bevel for a bit of depth
-  ctx.strokeStyle = '#111';
-  ctx.strokeRect(px + 0.5, py + 0.5, SIZE - 1, SIZE - 1);
+  context.strokeStyle = '#111';
+  context.strokeRect(px + 0.5, py + 0.5, size - 1, size - 1);
 }
 
 // --- Tetromino definitions (cell values match color indices) ---
@@ -125,6 +143,29 @@ function rotate(mat, dir = 1) {
 
 // Active piece state
 let piece = null;
+let next = null;
+let hold = null;
+let holdUsed = false;
+
+function randomMatrix() {
+  const types = Object.keys(SHAPES);
+  const t = types[Math.floor(Math.random() * types.length)];
+  return SHAPES[t].map(row => row.slice());
+}
+
+function renderPreview(context, mat, canvas) {
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  if (!mat) return;
+  const offsetX = Math.floor((4 - mat[0].length) / 2);
+  const offsetY = Math.floor((4 - mat.length) / 2);
+  for (let y = 0; y < mat.length; y++) {
+    for (let x = 0; x < mat[y].length; x++) {
+      const v = mat[y][x];
+      if (!v) continue;
+      drawCell(x + offsetX, y + offsetY, COLORS[v], context);
+    }
+  }
+}
 
 // Draw any matrix onto the canvas at (offX, offY)
 function drawMatrix(mat, offX, offY) {
@@ -141,16 +182,33 @@ function drawMatrix(mat, offX, offY) {
   }
 }
 
-// Spawn a random tetromino centered at the top
+// Spawn the next tetromino centered at the top
 function spawn() {
-  const types = Object.keys(SHAPES);
-  const t = types[Math.floor(Math.random() * types.length)];
-  const mat = SHAPES[t].map(row => row.slice()); // shallow clone
+  const mat = next;
   piece = {
     matrix: mat,
     x: Math.floor((COLS - mat[0].length) / 2),
-    y: -1, // start just above the board so tall pieces slide in
+    y: -1,
   };
+  next = randomMatrix();
+  renderPreview(nextCtx, next, nextCanvas);
+  holdUsed = false;
+  renderPreview(holdCtx, hold, holdCanvas);
+}
+
+function holdPiece() {
+  if (holdUsed) return;
+  if (hold) {
+    [piece.matrix, hold] = [hold, piece.matrix];
+    piece.x = Math.floor((COLS - piece.matrix[0].length) / 2);
+    piece.y = -1;
+  } else {
+    hold = piece.matrix;
+    spawn();
+  }
+  holdUsed = true;
+  renderPreview(holdCtx, hold, holdCanvas);
+  render();
 }
 
 // Check if matrix at (offX, offY) is a valid position (no collisions)
@@ -401,6 +459,8 @@ window.addEventListener('keydown', (e) => {
   else if (e.code === 'Space') {
     if (!e.repeat) hardDrop(); // ignore key-repeat so it only fires once
     e.preventDefault();
+  } else if (e.key === 'c' || e.key === 'C' || e.key === 'Shift') {
+    holdPiece(); e.preventDefault();
   }
 
 });
@@ -417,10 +477,7 @@ window.addEventListener('keyup', (e) => {
     softTimer = 0;
   }
 });
-
-
-
-
+next = randomMatrix();
 spawn();
 updateHUD();
 requestAnimationFrame(update);


### PR DESCRIPTION
## Summary
- show upcoming tetromino and allow holding pieces in Tetris
- document hold controls and preview feature in README and AGENTS notes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d23dbd714832ba42f4cede8a30995