### PR TITLE
Add mobile touch controls to Tetris game

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,4 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Theme bar allows switching between "dark", "light", and "forest" themes using a fixed selector on every page.
 - Portfolio now includes pages for my Final Year Project and Year 2 Java calculator.
 - Games page now lists a playable Tetris subpage.
+- Tetris game now supports on-screen mobile controls for touch devices.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm run dev
 - Manage posts and projects from Netlify CMS at `/admin`
 - Responsive Tailwind styling
 - Includes dedicated pages for my Final Year Project and Year 2 Java calculator
-- Playable Tetris clone on the Games page
+- Playable Tetris clone on the Games page with touch controls on mobile
 
 ## Project Structure
 

--- a/src/pages/games/tetris.astro
+++ b/src/pages/games/tetris.astro
@@ -12,6 +12,12 @@ import Layout from '../../layouts/Layout.astro';
       <p>Level: <span id="level">0</span></p>
     </div>
   </div>
+  <div class="md:hidden mt-4 flex gap-2">
+    <button id="btn-left" class="px-4 py-2 bg-gray-700 text-white rounded">◀</button>
+    <button id="btn-rotate" class="px-4 py-2 bg-gray-700 text-white rounded">⟳</button>
+    <button id="btn-right" class="px-4 py-2 bg-gray-700 text-white rounded">▶</button>
+    <button id="btn-drop" class="px-4 py-2 bg-gray-700 text-white rounded">⬇</button>
+  </div>
   <script>
 const COLS = 10;
 const ROWS = 20;
@@ -417,9 +423,22 @@ window.addEventListener('keyup', (e) => {
     softTimer = 0;
   }
 });
+const btnLeft = document.getElementById('btn-left');
+const btnRight = document.getElementById('btn-right');
+const btnRotate = document.getElementById('btn-rotate');
+const btnDrop = document.getElementById('btn-drop');
 
-
-
+if (btnLeft && btnRight && btnRotate && btnDrop) {
+  function bindButton(el, down, up) {
+    el.addEventListener('pointerdown', (e) => { e.preventDefault(); down(); });
+    el.addEventListener('pointerup', (e) => { e.preventDefault(); if (up) up(); });
+    el.addEventListener('pointerleave', () => { if (up) up(); });
+  }
+  bindButton(btnLeft, () => { keys.left = true; setHoriz(-1); }, () => { keys.left = false; setHoriz(keys.right ? 1 : 0); });
+  bindButton(btnRight, () => { keys.right = true; setHoriz(1); }, () => { keys.right = false; setHoriz(keys.left ? -1 : 0); });
+  btnRotate.addEventListener('pointerdown', (e) => { e.preventDefault(); tryRotate(1); });
+  btnDrop.addEventListener('pointerdown', (e) => { e.preventDefault(); hardDrop(); });
+}
 
 spawn();
 updateHUD();


### PR DESCRIPTION
## Summary
- add on-screen buttons for mobile Tetris
- document mobile controls in README
- note mobile support in AGENTS guidelines

## Testing
- `npm test` (fails: missing script)
- `npm run lint` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d246bbc60832b8475556d26afc928