### PR TITLE
Serve client build in container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Dockerfile and docker-compose.yml allow containerized builds with `docker compose up --build`.
 - The container will run `git pull` on startup using `GIT_REPO` and rebuild the site automatically.
 - `.env.example` now includes optional `GIT_REPO` and `GIT_BRANCH` variables.
-- Docker entrypoint should copy the build output to `/var/www/html` since that's
+- Docker entrypoint should copy the built client output to `/var/www/html` since that's
   the default Nginx root.
 - Docker listens on port `8484` by default via `docker-compose.yml`.
 - Astro now uses the Node adapter so API routes can save data server-side.
@@ -68,3 +68,4 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Pieces have a lock delay so I can slide them before they settle
 - Tetris now saves high scores in a cookie, prompts for a username and shows a local leaderboard of past runs
 - Tetris now posts scores to a simple API so there's a global top ten leaderboard across visitors
+- Docker entrypoint now copies `dist/client` to `/var/www/html` so Nginx serves `index.html` correctly after the Node adapter build

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ docker compose up --build
 
 The site will be available at http://localhost:8484. Can also set `GIT_REPO` to a GitHub URL so the container pulls the latest changes each time it starts. Optionally set `GIT_BRANCH` if a branch other than `main` is needed.
 Remember to provide `LASTFM_USER` and `LASTFM_API_KEY` in your environment when building.
+After the build finishes, the entrypoint copies the contents of `dist/client` to `/var/www/html` so Nginx serves the generated `index.html` instead of returning a 403.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,6 +17,7 @@ cd /app
 npm install
 npm run build
 rm -rf /var/www/html/*
-cp -r dist/* /var/www/html/
+# Astro's Node adapter outputs the static site to dist/client, so copy that to nginx's root
+cp -r dist/client/* /var/www/html/
 
 nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- Copy the Astro client build to nginx's web root so the container serves `index.html` instead of returning 403.
- Document the new copy step in the README and agent notes.