### PR TITLE
Store Tetris high scores in localStorage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ This project contains the source for **korikosmos.dev**, a personal site built w
 - Tetris mobile controls now include hold and counter-clockwise rotation buttons
 - Piece speed now scales with level and the HUD shows the current level
 - Pieces have a lock delay so I can slide them before they settle
-- Tetris now saves high scores in a cookie, prompts for a username and shows a local leaderboard of past runs
+- Tetris now saves high scores in localStorage, prompts for a username and shows a local leaderboard of past runs
 - Tetris now posts scores to a simple API so there's a global top ten leaderboard across visitors
 - Tetris scoring now follows the official guidelines with soft and hard drop bonuses
 - Games page now includes a Rock Paper Scissors game with scores saved to localStorage

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run dev
 - Includes dedicated pages for my Final Year Project and Year 2 Java calculator
 - I built a playable Tetris clone for the Games page with touch controls (including hold and counter-clockwise rotation buttons), a next-piece preview that matches the seven-piece bag, level-based speed shown in the HUD, a lock delay so pieces can slide before settling, a hold function (press C, Shift or tap Hold), and the Super Rotation System (SRS)
 - I also added a simple Rock Paper Scissors game that saves scores in `localStorage`
-- The Tetris game now asks for a username, stores my best score in a cookie, keeps a local leaderboard of top runs, and submits scores to a global top ten board for everyone who visits
+- The Tetris game now asks for a username, stores my best score in localStorage, keeps a local leaderboard of top runs, and submits scores to a global top ten board for everyone who visits
 - My Tetris clone now uses official scoring, including soft and hard drop bonuses
 
 The global board saves to `src/data/tetris-scores.json` through a simple API route, so I can reset it by editing that file.

--- a/src/pages/games/tetris.astro
+++ b/src/pages/games/tetris.astro
@@ -67,24 +67,13 @@ scaleForHiDPI(nextCanvas, nextCtx);
 scaleForHiDPI(holdCanvas, holdCtx);
 
 // --- User & High Score ---
-function getCookie(name) {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop().split(';').shift();
-}
-
-function setCookie(name, value, days) {
-  const expires = new Date(Date.now() + days * 864e5).toUTCString();
-  document.cookie = `${name}=${value}; expires=${expires}; path=/`;
-}
-
 let username = localStorage.getItem('tetris_username');
 while (!username) {
   username = prompt('Enter a username:')?.trim();
 }
 localStorage.setItem('tetris_username', username);
 
-let highScore = parseInt(getCookie('tetris_highscore') || '0', 10);
+let highScore = parseInt(localStorage.getItem('tetris_highscore') || '0', 10);
 
 function loadLocalLeaderboard() {
   try {
@@ -479,7 +468,7 @@ async function lockPiece() {
   if (!isValidPosition(piece.matrix, piece.x, piece.y)) {
     if (score > highScore) {
       highScore = score;
-      setCookie('tetris_highscore', highScore, 365);
+      localStorage.setItem('tetris_highscore', highScore.toString());
     }
     localLeaderboard.push({ name: username, score });
     localLeaderboard.sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Summary
- persist Tetris personal best in browser localStorage instead of cookies
- document the new storage method in README and AGENTS notes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7bd4c85d0832b927991d472686b8b